### PR TITLE
Allow macro functions on Response

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -7,11 +7,14 @@ use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
 class Response extends BaseResponse
 {
-    use ResponseTrait;
+    use ResponseTrait, Macroable {
+        Macroable::__call as macroCall;
+    }
 
     /**
      * Set the content on the response.


### PR DESCRIPTION
Specific types of responses like Illuminate\Http\RedirectResponse already use Macroable. We should also enable it for Illuminate\Http\JsonResponse

I'm using the Macro feature to add special headers to my responses so this change has a very practical use.